### PR TITLE
Implement and test as_matrix

### DIFF
--- a/include/flash/core.hpp
+++ b/include/flash/core.hpp
@@ -90,7 +90,6 @@ template <typename SingleChannelView, blaze::AlignmentFlag IsAligned = blaze::un
           blaze::PaddingFlag IsPadded = blaze::unpadded, bool StorageOrder = blaze::rowMajor>
 auto as_matrix(SingleChannelView source)
 {
-    using pixel_t = typename SingleChannelView::value_type;
     using channel_t = typename boost::gil::channel_type<SingleChannelView>::type;
     return blaze::CustomMatrix<channel_t, IsAligned, IsPadded, StorageOrder>(
         reinterpret_cast<channel_t*>(&source(0, 0)), source.height(), source.width());

--- a/include/flash/core.hpp
+++ b/include/flash/core.hpp
@@ -86,6 +86,18 @@ auto to_matrix_channeled(View view)
         }));
 }
 
+/** \brief constructs `blaze::CustomMatrix` out of `image_view`
+
+    Creates a matrix which is semantically like pointer, e.g. changes in the matrix
+    will be reflected inside the view, and vice versa. Do note that assigning to another
+    `blaze::CustomMatrix` will behave like shallow copy, thus it is important to perform
+    deep copy using e.g. `blaze::DynamicMatrix` to have independent copy.
+
+    The input view must have single channel pixels like `boost::gil::gray8_view_t`,
+    for multi-channel matrices please first check layout compatibility of the pixel type
+    and corresponding `blaze::StaticVector<ChannelType, num_channels>`, then use
+    `as_matrix_channeled`.
+*/
 template <typename SingleChannelView, blaze::AlignmentFlag IsAligned = blaze::unaligned,
           blaze::PaddingFlag IsPadded = blaze::unpadded, bool StorageOrder = blaze::rowMajor>
 auto as_matrix(SingleChannelView source)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,6 @@ endif()
 
 include(Catch)
 
-add_executable(test_target remap_test.cpp to_matrix_test.cpp rm_cvref_test.cpp pixel_to_vector_test.cpp vector_to_pixel_test.cpp to_image_test.cpp)
+add_executable(test_target remap_test.cpp to_matrix_test.cpp rm_cvref_test.cpp pixel_to_vector_test.cpp vector_to_pixel_test.cpp to_image_test.cpp as_matrix_test.cpp)
 target_link_libraries(test_target PRIVATE Catch2::Catch2 blazing-gil)
 catch_discover_tests(test_target)

--- a/test/as_matrix_test.cpp
+++ b/test/as_matrix_test.cpp
@@ -1,0 +1,122 @@
+#include <catch2/catch.hpp>
+
+#include <flash/core.hpp>
+
+namespace gil = boost::gil;
+
+template <typename T>
+struct printer;
+
+gil::gray8_pixel_t zero_gray8_pixel(0);
+
+TEST_CASE("as_matrix typecheck for gray8_image", "[as_matrix]")
+{
+    gil::gray8_image_t image(16, 16, zero_gray8_pixel);
+    auto view = gil::view(image);
+
+    auto result = flash::as_matrix(view);
+    using expected_t = blaze::CustomMatrix<gil::uint8_t, blaze::unaligned, blaze::unpadded, blaze::rowMajor>;
+    STATIC_REQUIRE(std::is_same_v<decltype(result), expected_t>);
+}
+
+TEST_CASE("as_matrix gray8_image zero value_check")
+{
+    gil::gray8_image_t image(16, 16, zero_gray8_pixel);
+    auto view = gil::view(image);
+
+    auto result = flash::as_matrix(view);
+    REQUIRE(blaze::isZero(result));    
+}
+
+TEST_CASE("as_matrix gray8_image modify matrix")
+{
+    gil::gray8_image_t image(16, 16, zero_gray8_pixel);
+    auto view = gil::view(image);
+
+    auto result = flash::as_matrix(view);
+    gil::gray8_image_t image2(16, 16, zero_gray8_pixel);
+    auto expected_before_modify = gil::view(image2);
+    REQUIRE(gil::equal_pixels(view, expected_before_modify));
+
+    gil::uint8_t value = 23;
+    result(1, 0) = value; // do not forget Blaze's different indexing
+    REQUIRE(view(0, 1)[0] == value);
+
+    std::uint8_t value2 = 40;
+    result(3, 2) = value2;
+    REQUIRE(view(2, 3)[0] == value2);
+}
+
+TEST_CASE("as_matrix gray8_image modify image")
+{
+    gil::gray8_image_t image(16, 16, zero_gray8_pixel);
+    auto view = gil::view(image);
+
+    auto result = flash::as_matrix(view);
+    auto expected_before_modify = blaze::zero<gil::uint8_t>(16, 16);
+    REQUIRE(result == expected_before_modify);
+    gil::uint8_t value = 23;
+    view(1, 0)[0] = value;
+    REQUIRE(result(0, 1) == value);
+
+    std::uint8_t value2 = 40;
+    view(3, 2)[0] = value2;
+    REQUIRE(result(2, 3) == value2);
+}
+
+TEST_CASE("as_matrix typecheck for gray16_image", "[as_matrix]")
+{
+    gil::gray16_image_t image(16, 16);
+    auto view = gil::view(image);
+
+    auto result = flash::as_matrix(view);
+    using expected_t = blaze::CustomMatrix<gil::uint16_t, blaze::unaligned, blaze::unpadded, blaze::rowMajor>;
+    STATIC_REQUIRE(std::is_same_v<decltype(result), expected_t>);    
+}
+
+gil::gray16_pixel_t zero_gray16_pixel(0);
+
+TEST_CASE("as_matrix gray16_image zero value_check")
+{
+    gil::gray16_image_t image(16, 16, zero_gray16_pixel);
+    auto view = gil::view(image);
+
+    auto result = flash::as_matrix(view);
+    REQUIRE(blaze::isZero(result));    
+}
+
+TEST_CASE("as_matrix gray16_image modify matrix")
+{
+    gil::gray16_image_t image(16, 16, zero_gray16_pixel);
+    auto view = gil::view(image);
+
+    auto result = flash::as_matrix(view);
+    gil::gray16_image_t image2(16, 16, zero_gray16_pixel);
+    auto expected_before_modify = gil::view(image2);
+    REQUIRE(gil::equal_pixels(view, expected_before_modify));
+
+    gil::uint16_t value = 23;
+    result(1, 0) = value; // do not forget Blaze's different indexing
+    REQUIRE(view(0, 1)[0] == value);
+
+    std::uint16_t value2 = 40;
+    result(3, 2) = value2;
+    REQUIRE(view(2, 3)[0] == value2);
+}
+
+TEST_CASE("as_matrix gray16_image modify image")
+{
+    gil::gray16_image_t image(16, 16, zero_gray16_pixel);
+    auto view = gil::view(image);
+
+    auto result = flash::as_matrix(view);
+    auto expected_before_modify = blaze::zero<gil::uint16_t>(16, 16);
+    REQUIRE(result == expected_before_modify);
+    gil::uint16_t value = 23;
+    view(1, 0)[0] = value;
+    REQUIRE(result(0, 1) == value);
+
+    std::uint16_t value2 = 40;
+    view(3, 2)[0] = value2;
+    REQUIRE(result(2, 3) == value2);
+}


### PR DESCRIPTION
The implementation was mostly salvaged from previous `to_matrix`. It breaks all examples. They didn't have tests, so technically they didn't work in the first place.

Closes #12 