### PR TITLE
Densify core

### DIFF
--- a/include/flash/core.hpp
+++ b/include/flash/core.hpp
@@ -275,8 +275,8 @@ auto as_matrix_channeled(ImageView source)
 // only use with blaze::min and blaze::max
 // note that this is intended to narrow from source range
 // to destination range
-template <typename U, typename SourceMatrix, typename T>
-auto remap_to(const SourceMatrix& source, T src_min, T src_max,
+template <typename U, typename MT, bool StorageOrder, typename T>
+auto remap_to(const blaze::DenseMatrix<MT, StorageOrder>& source, T src_min, T src_max,
               U dst_min = std::numeric_limits<U>::min(), U dst_max = std::numeric_limits<U>::max())
 {
     // ensure that dst_max - dst_min will not overflow
@@ -291,8 +291,8 @@ auto remap_to(const SourceMatrix& source, T src_min, T src_max,
                       });
 }
 
-template <typename U, typename SourceMatrix>
-auto remap_to(const SourceMatrix& source)
+template <typename U, typename MT, bool StorageOrder>
+auto remap_to(const blaze::DenseMatrix<MT, StorageOrder>& source)
 {
     return remap_to<U>(source, blaze::min(source), blaze::max(source));
 }

--- a/include/flash/core.hpp
+++ b/include/flash/core.hpp
@@ -476,31 +476,31 @@ void from_matrix(const blaze::DenseMatrix<MT, SO>& data, ImageView view)
         blaze::IsDenseVector<blaze::UnderlyingElement_t<MT>>{}, view, data);
 }
 
-template <typename T, typename U>
-blaze::DynamicMatrix<T> pad(const blaze::DynamicMatrix<T>& source, std::size_t pad_count,
+template <typename MT, bool StorageOrder, typename U>
+auto pad(const blaze::DenseMatrix<MT, StorageOrder>& source, std::size_t pad_count,
                             const U& padding_value)
 {
-    static_assert(std::is_convertible_v<T, U>);
+    using element_type = blaze::UnderlyingElement_t<MT>;
+    static_assert(std::is_convertible_v<element_type, U>);    
+    blaze::DynamicMatrix<element_type> result((~source).rows() + pad_count * 2, (~source).columns() + pad_count * 2);
 
-    blaze::DynamicMatrix<T> result(source.rows() + pad_count * 2, source.columns() + pad_count * 2);
-
-    auto full_resulting_width = source.columns() + pad_count * 2;
+    auto full_resulting_width = (~source).columns() + pad_count * 2;
     // first pad_count rows
     blaze::submatrix(result, 0, 0, pad_count, full_resulting_width) = padding_value;
     // last pad_count rows
-    blaze::submatrix(result, source.rows(), 0, pad_count, full_resulting_width) = padding_value;
+    blaze::submatrix(result, (~source).rows(), 0, pad_count, full_resulting_width) = padding_value;
 
-    auto vertical_block_height = source.rows();
+    auto vertical_block_height = (~source).rows();
     // left pad_count columns, do note that top pad_count rows are already
     // filled
     blaze::submatrix(result, pad_count, 0, vertical_block_height, pad_count) = padding_value;
     // right pad_count columns, do note that top pad_count rows are already
     // filled
-    blaze::submatrix(result, pad_count, source.columns(), vertical_block_height, pad_count) =
+    blaze::submatrix(result, pad_count, (~source).columns(), vertical_block_height, pad_count) =
         padding_value;
 
     // don't forget to copy the original contents
-    blaze::submatrix(result, pad_count, pad_count, source.rows(), source.columns()) = source;
+    blaze::submatrix(result, pad_count, pad_count, (~source).rows(), (~source).columns()) = source;
 
     return result;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,8 @@ add_executable(test_target
     from_matrix_test.cpp 
     as_matrix_test.cpp
     as_matrix_channeled_test.cpp
-    true_channel_type_test.cpp)
+    true_channel_type_test.cpp
+    pad_test.cpp)
 target_link_libraries(test_target PRIVATE Catch2::Catch2 blazing-gil)
 target_compile_options(test_target PRIVATE
 $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>

--- a/test/pad_test.cpp
+++ b/test/pad_test.cpp
@@ -1,0 +1,43 @@
+#include <catch2/catch.hpp>
+
+#include <blaze/Blaze.h>
+#include <flash/core.hpp>
+
+TEST_CASE("simple pad case", "[pad]")
+{
+    std::size_t base_dimension = 8;
+    for (std::size_t i = 1; i < 3; ++i)
+    {
+        blaze::DynamicMatrix<int> input(base_dimension, base_dimension, 0);
+        blaze::DynamicMatrix<int> expected(base_dimension + i * 2, base_dimension + i * 2, 0);
+        auto result = flash::pad(input, i, 0);
+        REQUIRE(result.rows() == expected.rows());
+        REQUIRE(result.columns() == expected.columns());
+        REQUIRE(result == expected);
+    }
+}
+
+TEST_CASE("harder pad case", "[pad]")
+{
+    std::size_t base_dimension = 8;
+    int value = 23;
+    int pad_value = 11;
+    for (std::size_t i = 1; i < 3; ++i)
+    {
+        blaze::DynamicMatrix<int> input(base_dimension, base_dimension, value);
+        auto result = flash::pad(input, i, pad_value);
+        // check surrounding values first
+        // upper rows
+        REQUIRE(blaze::submatrix(result, 0, 0, i, result.columns()) == pad_value);
+        // left columns
+        REQUIRE(blaze::submatrix(result, 0, 0, result.rows(), i) == pad_value);
+        // right columns
+        REQUIRE(blaze::submatrix(result, 0, input.columns() + i, result.rows(), i) == pad_value);
+        // lower rows
+        REQUIRE(blaze::submatrix(result, input.rows() + i, 0, i, result.columns()) == pad_value);
+
+        //check center
+        REQUIRE(blaze::submatrix(result, i, i, input.rows(), input.columns()) == value);
+    }
+}
+

--- a/test/remap_test.cpp
+++ b/test/remap_test.cpp
@@ -6,6 +6,33 @@
 
 #include <flash/core.hpp>
 
+TEST_CASE("test remap_to - simple case", "[remap_test]")
+{
+    std::uint16_t value = 23;
+    blaze::DynamicMatrix<std::uint16_t> input(16, 16, value);
+    auto result = flash::remap_to<std::uint8_t>(input);
+    REQUIRE(blaze::isZero(result));
+}
+
+TEST_CASE("test remap_to - slightly harder case", "[remap_test]")
+{
+    blaze::DynamicMatrix<std::uint16_t> input(16, 16);
+    blaze::DynamicMatrix<std::uint8_t> expected(16, 16);
+    std::uint8_t counter = 0;
+    for (std::size_t i = 0; i < input.rows(); ++i)
+    {
+        for (std::size_t j = 0; j < input.columns(); ++j)
+        {
+            input(i, j) = counter;
+            expected(i, j) = counter;
+            ++counter;
+        }
+    }
+
+    auto result = flash::remap_to<std::uint8_t>(input);
+    REQUIRE(result == expected);
+}
+
 TEST_CASE("test remap_to_channeled - simple case", "[remap_test]")
 {
     blaze::StaticVector<int, 3> default_vector({0, 1, 2});


### PR DESCRIPTION
Now all relevant functions use `blaze::DenseMatrix` or `blaze::DenseVector`.

Closes #24 